### PR TITLE
Support connection to Mosquitto through unix socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ vendor/
 debian/*.debhelper
 debian/*.log
 debian/*.substvars
+debian/debhelper-build-stamp
+debian/files
 
 # Lvim
 .lvimrc

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SNMP to MQTT gateway
 
 Драйвер SNMP для Wiren Board.
 
-Документация здесь: http://contactless.ru/wiki/index.php/Драйвер_SNMP
+Документация здесь: https://wirenboard.com/wiki/index.php/Драйвер_SNMP
 
 Зависимости
 -----------

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-snmp (1.2.2) stable; urgency=medium
+
+  * Support connection to Mosquitto through unix socket
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 28 Feb 2023 18:39:00 +0400
+
 wb-mqtt-snmp (1.2.1) stable; urgency=medium
 
   * Fixed a bug where /meta/error was not cleared

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.13
 
 require (
 	github.com/alouca/gologger v0.0.0-20120904114645-7d4b7291de9c
-	github.com/contactless/org.eclipse.paho.mqtt.golang v0.0.0-20160512050345-bc107ec72972 // indirect
-	github.com/contactless/wbgo v0.0.0-20220121122043-0ed1df7257ab
+	github.com/contactless/org.eclipse.paho.mqtt.golang v0.0.0-20230303073519-735a2c3f9cde // indirect
+	github.com/contactless/wbgo v0.0.0-20230303092421-d61f66227d17
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,11 +2,15 @@ github.com/alouca/gologger v0.0.0-20120904114645-7d4b7291de9c h1:k/7/05/5kPRX7Ha
 github.com/alouca/gologger v0.0.0-20120904114645-7d4b7291de9c/go.mod h1:SI1d/2/wpSTDjHgdS9ZLy6hqvsdhzVYAc8RLztweMpA=
 github.com/contactless/org.eclipse.paho.mqtt.golang v0.0.0-20160512050345-bc107ec72972 h1:itvKwLlIg3MLdjVqhPuYFd0y9RsrQQxSIhZXUeNFtmA=
 github.com/contactless/org.eclipse.paho.mqtt.golang v0.0.0-20160512050345-bc107ec72972/go.mod h1:ISd8VT87v5vB6N33PDJrbWYlI0+r46JxZ9+yEDTKThc=
+github.com/contactless/org.eclipse.paho.mqtt.golang v0.0.0-20230303073519-735a2c3f9cde h1:ToxrsyexBWyjTPfZ0Px49EAlXEurWtEYucYnr8g8G3U=
+github.com/contactless/org.eclipse.paho.mqtt.golang v0.0.0-20230303073519-735a2c3f9cde/go.mod h1:ISd8VT87v5vB6N33PDJrbWYlI0+r46JxZ9+yEDTKThc=
 github.com/contactless/wbgo v0.0.0-20170113112953-645ba6f5f8fd h1:0eOGK7ytp7a5qUDOi4zOeywmcfyzGZOnvui4tamc5so=
 github.com/contactless/wbgo v0.0.0-20220120105130-8c1ce2c7a52f h1:zW0e9scDN+NusD/BIbfV8M2FgjvdwZi5vTdkrzQidw0=
 github.com/contactless/wbgo v0.0.0-20220120105130-8c1ce2c7a52f/go.mod h1:zpSgGrFuNosiXs0VtRMXlWLyddi9QYrq5v+a4WuUU9s=
 github.com/contactless/wbgo v0.0.0-20220121122043-0ed1df7257ab h1:OQUa4mX9q4XgZJFOOze5G51AswyNow7q5EML4nhL5ZE=
 github.com/contactless/wbgo v0.0.0-20220121122043-0ed1df7257ab/go.mod h1:zpSgGrFuNosiXs0VtRMXlWLyddi9QYrq5v+a4WuUU9s=
+github.com/contactless/wbgo v0.0.0-20230303092421-d61f66227d17 h1:wD5ORFOlmoyEZhhf83TlGkhTwb2bFpbLT0U/ZVuCSuY=
+github.com/contactless/wbgo v0.0.0-20230303092421-d61f66227d17/go.mod h1:zpSgGrFuNosiXs0VtRMXlWLyddi9QYrq5v+a4WuUU9s=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 		}
 	}()
 
-	broker := flag.String("broker", "tcp://localhost:1883", "MQTT broker URL")
+	broker := flag.String("broker", "unix:///var/run/mosquitto/mosquitto.sock", "MQTT broker URL")
 	configFile := flag.String("config", "/etc/wb-mqtt-snmp.conf", "Config file location")
 	templatesDir := flag.String("templates", "/usr/share/wb-mqtt-snmp/templates/", "Templates directory")
 	debug := flag.Bool("debug", false, "Enable debugging")


### PR DESCRIPTION
Test instructions:
```sh
$ sed -i 's/bullseye main/bullseye main non-free/' /etc/apt/sources.list.d/debian-upstream.list
$ apt install snmp-mibs-downloader
$ wb-mqtt-snmp
2023/03/03 13:31:48 command to run: snmptranslate []string{"SNMPv2-MIB::sysName.0", "SNMPv2-MIB::sysORDescr.1", "SNMPv2-MIB::sysContact.0"} -On
INFO: 2023/03/03 13:31:48 MQTT connection established
...
$ wb-mqtt-snmp -broker unix:///var/run/mosquitto/mosquitto.sock
2023/03/03 13:30:36 command to run: snmptranslate []string{"SNMPv2-MIB::sysName.0", "SNMPv2-MIB::sysORDescr.1", "SNMPv2-MIB::sysContact.0"} -On
INFO: 2023/03/03 13:30:37 MQTT connection established
...
$ wb-mqtt-snmp -broker tcp://127.0.0.1:1883
2023/03/03 13:31:26 command to run: snmptranslate []string{"SNMPv2-MIB::sysORDescr.1", "SNMPv2-MIB::sysContact.0", "SNMPv2-MIB::sysName.0"} -On
INFO: 2023/03/03 13:31:26 MQTT connection established
...
```

Before:
```sh
$ wb-mqtt-snmp -broker unix:///var/run/mosquitto/mosquitto.sock
2023/03/03 13:38:30 command to run: snmptranslate []string{"SNMPv2-MIB::sysName.0", "SNMPv2-MIB::sysORDescr.1", "SNMPv2-MIB::sysContact.0"} -On
stacktrace from panic:
goroutine 1 [running]:
runtime/debug.Stack(0x913e04, 0x264998, 0x89efd8)
	/usr/lib/go-1.15/src/runtime/debug/stack.go:24 +0x78
main.main.func1()
	/build/wb-mqtt-snmp-hSFb1T/wb-mqtt-snmp-1.2.1/main.go:18 +0x30
panic(0x264998, 0x89efd8)
	/usr/lib/go-1.15/src/runtime/panic.go:969 +0x158
github.com/contactless/wbgo.(*PahoMQTTClient).Start(0x8945d0)
	/sbuild-nonexistent/go/pkg/mod/github.com/contactless/wbgo@v0.0.0-20220121122043-0ed1df7257ab/mqtt.go:134 +0x148
github.com/contactless/wbgo.(*Driver).Start(0x8b65a0, 0xbeb0753a, 0x28)
	/sbuild-nonexistent/go/pkg/mod/github.com/contactless/wbgo@v0.0.0-20220121122043-0ed1df7257ab/driver.go:582 +0x3c
main.main()
	/build/wb-mqtt-snmp-hSFb1T/wb-mqtt-snmp-1.2.1/main.go:57 +0x358
```

https://github.com/wirenboard/wbgo/pull/2