### PR TITLE
Ignore scale option for non-numeric channels

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-snmp (1.2.9) stable; urgency=medium
+
+  * Ignore scale option for non-numeric channels
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 15 Jul 2024 17:00:00 +0400
+
 wb-mqtt-snmp (1.2.8) stable; urgency=medium
 
   * Backup config by moving to /mnt/data

--- a/mqtt_snmp/config_parser.go
+++ b/mqtt_snmp/config_parser.go
@@ -636,14 +636,14 @@ func (d *DeviceConfig) parseChannelEntry(channel map[string]interface{}) error {
 	// converter is an optional function depends on control type
 	// now scale function is presented only
 	if _, ok := channel["scale"]; ok {
-		if !isNumericControlType(c.ControlType) {
-			return fmt.Errorf("scale could be applied only to numeric control type")
-		} else {
+		if isNumericControlType(c.ControlType) {
 			var scale float64
 			if err := copyFloat64(&channel, "scale", &scale, false); err != nil {
 				return err
 			}
 			c.Conv = Scale(scale)
+		} else {
+			wbgo.Warn.Println("scale could be applied only to numeric control type")
 		}
 	}
 


### PR DESCRIPTION
Сейчас наличие scale у текстового контрола приводит к тому, что сервис не стартует, а пользователь в UI об этом не узнает при сохранении конфига:
```bash
wb-mqtt-snmp[24678]: ERROR: 2024/07/15 19:52:36 error parsing config file /etc/wb-mqtt-snmp.conf: channel parse error in snmp_127.0.0.1_public: scale could be applied only to numeric control type
systemd[1]: wb-mqtt-snmp.service: Main process exited, code=exited, status=6/NOTCONFIGURED
systemd[1]: wb-mqtt-snmp.service: Failed with result 'exit-code'.
```