### PR TITLE
Fix snmp connection usage from multiple workers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-snmp (1.3.7) stable; urgency=medium
+
+  * Fix snmp connection usage from multiple workers
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Sun, 27 Oct 2024 18:45:00 +0400
+
 wb-mqtt-snmp (1.3.6) stable; urgency=medium
 
   * Fix log priority


### PR DESCRIPTION
Старая бага, легко воспроизводится с таким конфигом:
```json
{
    "debug": false,
    "devices": [
        {
            "address": "127.0.0.1",
            "enabled": true,
            "community": "public",
            "channels": [
                {
                    "control_type": "value",
                    "enabled": true,
                    "name": "sysServices",
                    "oid": ".1.3.6.1.2.1.1.7.0"
                },
                {
                    "control_type": "text",
                    "enabled": true,
                    "name": "sysLocation",
                    "oid": ".1.3.6.1.2.1.1.6.0"
                }
            ],
            "name": "snmp-test"
        }
    ],
    "num_workers": 4
}
```

В результате постоянные ошибки в логах:
```sh
ERROR: 2024/07/17 05:48:17 failed to poll snmp_127.0.0.1_public:sysServices: Request ID mismatch: 54103616 != 1265690540
ERROR: 2024/07/17 05:48:17 failed to poll snmp_127.0.0.1_public:sysLocation: Request ID mismatch: 1265690540 != 54103616
ERROR: 2024/07/17 05:54:23 failed to poll snmp_127.0.0.1_public:uptimeFromOID: Request ID mismatch: 721369449 != 2073218181
ERROR: 2024/07/17 05:54:23 failed to poll snmp_127.0.0.1_public:sysLocation: Request ID mismatch: 2073218181 != 721369449
ERROR: 2024/07/17 05:54:44 failed to poll snmp_127.0.0.1_public:sysLocation: Request ID mismatch: 530062749 != 1843570114
ERROR: 2024/07/17 05:54:44 failed to poll snmp_127.0.0.1_public:uptimeFromOID: Request ID mismatch: 1843570114 != 530062749
```

Суть в том, что SNMP соединение создается одно на девайс, но при распределении запросов по воркерам это не учитывается, в результате с конфигом приведенным выше получаем 1 соединение используется одновременно в двух воркерах и запрос отправляется в одном, а ответ принимается уже в другом. Пока просто прикрыл запрос/ответ мьютексом, в будущем может стоит переделать на использование BULK-GET и запрашивать сразу все каналы у устройства одним запросом.