### PR TITLE
Add device_id/channel_name validation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-mqtt-snmp (1.4.1) stable; urgency=medium
 
   * Add device_id/channel_name validation
 
- -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com> Wed, 30 Jul 2025 15:00:00 +0400
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 30 Jul 2025 15:00:00 +0400
 
 wb-mqtt-snmp (1.4.0) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-snmp (1.4.1) stable; urgency=medium
+
+  * Add device_id/channel_name validation
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com> Wed, 30 Jul 2025 15:00:00 +0400
+
 wb-mqtt-snmp (1.4.0) stable; urgency=medium
 
   * Fix build with go 1.21

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), pkg-config, golang-go:native
+Build-Depends: debhelper (>= 9), golang-go:native
 Homepage: https://github.com/wirenboard/wb-mqtt-snmp
 
 Package: wb-mqtt-snmp

--- a/wb-mqtt-snmp.schema.json
+++ b/wb-mqtt-snmp.schema.json
@@ -33,8 +33,12 @@
           "type": "string",
           "title": "MQTT ID of the device",
           "description": "Used as a part of a MQTT topic name",
+          "pattern": "^[^$#+\\/]+$",
           "minLength": 1,
-          "propertyOrder": 20
+          "propertyOrder": 20,
+          "options": {
+            "patternmessage": "Invalid device name"
+          }
         },
         "address": {
           "type": "string",
@@ -120,8 +124,12 @@
           "type": "string",
           "title": "Control name",
           "description": "This name is displayed both in MQTT topic and UI",
+          "pattern": "^[^$#+\\/]+$",
           "minLength": 1,
-          "propertyOrder": 10
+          "propertyOrder": 10,
+          "options": {
+            "patternmessage": "Invalid control name"
+          }
         },
 
         "oid": {
@@ -230,6 +238,7 @@
       "Device name to be displayed in UI": "Заголовок карточки устройства в веб-интерфейсе контроллера",
       "MQTT ID of the device": "MQTT идентификатор устройства",
       "Used as a part of a MQTT topic name": "Используется как часть имени топика MQTT",
+      "Invalid device name": "Неверное имя устройства",
       "SNMP device address": "Адрес устройства SNMP",
       "May be either IP address or domain name": "Может быть IP-адресом или именем домена",
       "Device type": "Тип устройства",
@@ -247,6 +256,7 @@
       "Enable channel": "Включить канал",
       "Control name": "Имя элемента управления",
       "This name is displayed both in MQTT topic and UI": "Название канала устройства в MQTT и веб-интерфейсе контроллера",
+      "Invalid control name": "Неверное название канала",
       "Object ID": "Идентификатор объекта",
       "OID (starting from dot) or variable name from MIB": "OID (начиная с точки) или имя переменной из MIB",
       "Control type": "Тип элемента управления",


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Аналогично недавнему фиксу в рулесах https://github.com/wirenboard/wb-rules/pull/163, тут тоже device_id никак не валидировался.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
на вб
<img width="631" height="293" alt="Screen Shot 2025-07-30 at 23 42 04" src="https://github.com/user-attachments/assets/f817139d-300b-4ab1-8378-f721693c1e71" />


